### PR TITLE
Fix a couple of typos in lazytab-mode

### DIFF
--- a/lazytab.el
+++ b/lazytab.el
@@ -67,7 +67,7 @@ orgtbl syntax."
   (if lazytab-mode
       (progn  (define-key orgtbl-mode-map (kbd "<tab>") 'lazytab-org-table-next-field-maybe)
               (define-key orgtbl-mode-map (kbd "TAB") 'lazytab-org-table-next-field-maybe)
-              (add-hook 'cdlatex-tab-hook 'lazytab-cdlatex-or-orgtbl-next-field)))
-  (define-key orgtbl-mode-map (kbd "<tab>") 'org-table-next-field)
-  (define-key orgtbl-mode-map (kbd "TAb") 'org-table-next-field)
-  (remove-hook 'cdlatex-tab-hook 'lazytab-cdlatex-or-orgtbl-next-field))
+              (add-hook 'cdlatex-tab-hook 'lazytab-cdlatex-or-orgtbl-next-field))
+    (define-key orgtbl-mode-map (kbd "<tab>") 'org-table-next-field)
+    (define-key orgtbl-mode-map (kbd "TAB") 'org-table-next-field)
+    (remove-hook 'cdlatex-tab-hook 'lazytab-cdlatex-or-orgtbl-next-field)))


### PR DESCRIPTION
1. There was a misplaced ')' that closed the if too early.

2. The key "TAB" was written "TAb" (which means T followed by A followed by b!)